### PR TITLE
Render the README on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     name = 'pyramid_hsts',
     version = '1.3.0',
     description = 'HTTP Strict Transport Security for a Pyramid application.',
+    long_description = _read('README.md'),
+    long_description_content_type = 'text/markdown',
     author = 'James Arthur',
     author_email = 'thruflo@gmail.com',
     url = 'http://github.com/thruflo/pyramid_hsts',


### PR DESCRIPTION
This will require uploading a new release (e.g. 1.3.0.post0) using [twine](https://github.com/pypa/twine).